### PR TITLE
P12 optimisation

### DIFF
--- a/src/solutions/highly_divisible_triangular_number.rs
+++ b/src/solutions/highly_divisible_triangular_number.rs
@@ -1,9 +1,12 @@
 use crate::utils;
 
 pub fn solve() -> i64 {
-    let triangular = utils::Polygonal::new(3);
-    let result = triangular
-        .filter(|num| utils::Divisors::new(*num).count() >= 500)
+    let result = utils::Polygonal::new(3)
+        .filter(|&num| {
+            utils::PrimeDivisors::new(num)
+                .fold(1, |accumulator, (_, power)| accumulator * (power + 1))
+                >= 500
+        })
         .next()
         .unwrap();
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -503,6 +503,40 @@ impl Iterator for Divisors {
     }
 }
 
+/// Prime divisors iterator. Generates all prime divisors of a number in
+/// ascending order. Positive numbers only!
+pub struct PrimeDivisors {
+    num: i64,
+    divisor: i64,
+}
+impl PrimeDivisors {
+    pub fn new(num: i64) -> PrimeDivisors {
+        PrimeDivisors {
+            num: num,
+            divisor: 1,
+        }
+    }
+}
+impl Iterator for PrimeDivisors {
+    type Item = (i64, usize);
+    fn next(&mut self) -> Option<(i64, usize)> {
+        loop {
+            self.divisor += 1;
+            if self.num < self.divisor {
+                return None;
+            }
+            let mut power = 0;
+            while self.num % self.divisor == 0 {
+                self.num /= self.divisor;
+                power += 1;
+            }
+            if power > 0 {
+                return Some((self.divisor, power));
+            }
+        }
+    }
+}
+
 /// Primes iterator. Generates prime numbers by internally constructing the
 /// sieve of Eratosthenes. Differs from other iterators in that its method must
 /// be called in order to obtain an iterator.


### PR DESCRIPTION
Easily find the number of divisors of a number. Reduces the running time from 800 ms to 400 ms.