### PR TITLE
Fixed overflow on i686 systems in `SieveOfAtkin`.

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -579,6 +579,7 @@ impl PandigitalChecker {
 pub struct SieveOfAtkin {
     limit: usize,
     limit_rounded: usize,
+    limit_rounded_root: usize,
     sieve: Vec<u16>,
 }
 impl SieveOfAtkin {
@@ -612,6 +613,7 @@ impl SieveOfAtkin {
         let mut sieve_of_atkin = SieveOfAtkin {
             limit,
             limit_rounded,
+            limit_rounded_root: isqrt(limit_rounded as i64) as usize,
             sieve: vec![0; limit / 60 + 1],
         };
         sieve_of_atkin.init();
@@ -631,7 +633,7 @@ impl SieveOfAtkin {
         // Mark composite all numbers divisible by the squares of primes.
         let mut num: usize = 1;
         let mut offset = SieveOfAtkin::OFFSETS.iter().cycle();
-        for sieve_idx in 0..self.sieve.len() {
+        'sieve: for sieve_idx in 0..self.sieve.len() {
             for shift in 0..16 {
                 if self.sieve[sieve_idx] >> shift & 1 == 1 {
                     let num_sqr = num.pow(2);
@@ -646,6 +648,9 @@ impl SieveOfAtkin {
                     }
                 }
                 num += offset.next().unwrap();
+                if num > self.limit_rounded_root {
+                    break 'sieve;
+                }
             }
         }
     }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -639,7 +639,7 @@ impl SieveOfAtkin {
                     let num_sqr = num.pow(2);
                     for multiple in (num_sqr..)
                         .step_by(num_sqr)
-                        .take_while(|&num_sqr| num_sqr < self.limit_rounded)
+                        .take_while(|&multiple| multiple < self.limit_rounded)
                     {
                         let multiple_div_60 = multiple / 60;
                         let multiple_mod_60 = multiple % 60;


### PR DESCRIPTION
On Raspberry Pi OS running on an 32-bit VM, line 637 results in overflow while solving P10. When `num` equals 65,537 (a prime number), `num.pow(2)` would equal 4,295,098,369, which is beyond the range of the `usize` type on said OS.

https://github.com/tfpf/project-euler/blob/da256e7c2e89214636335b70369d495fc264c908/src/utils.rs#L636-L646

A simple check prevents this, and should also speed up the sieve of Atkin by ending the loop when there would be no use iterating further.