### PR TITLE
Upgrade Cargo on Alpine to allow using Criterion.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,7 @@ on:
   push:
     paths:
       - '.github/workflows/tests.yml'
+      - 'Dockerfile'
       - 'src/utils.rs'
       - 'res/*_test.txt'
   workflow_dispatch:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dev-dependencies]
-criterion = "0.4"
+criterion = "0.4.0"
 
 [[bench]]
 name = "benches"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 edition = "2021"
 
 [dev-dependencies]
-criterion = "0.5.0"
+criterion = "0.4"
 
 [[bench]]
 name = "benches"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM --platform=linux/i386 alpine:3.19
 RUN apk add cargo
+RUN rustup update
 WORKDIR /project-euler
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM --platform=linux/i386 alpine:3.19
-RUN apk add cargo
+RUN apk add cargo rustup
 RUN rustup update
 WORKDIR /project-euler
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM --platform=linux/i386 alpine:3.19
-RUN apk add cargo rustup
-RUN rustup update
+RUN apk add cargo
 WORKDIR /project-euler
 COPY . .


### PR DESCRIPTION
It requires a newer version of Rust.