### PR TITLE
Indefinite prime sieve

### DIFF
--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -8,9 +8,15 @@ pub fn is_prime(c: &mut criterion::Criterion) {
 
 pub fn sieve_of_atkin(c: &mut criterion::Criterion) {
     c.bench_function("sieve_of_atkin", |b| {
-        b.iter(|| utils::SieveOfAtkin::new(10usize.pow(6)))
+        b.iter(|| utils::SieveOfAtkin::new(10usize.pow(6)).iter().count())
     });
 }
 
-criterion::criterion_group!(benches, is_prime, sieve_of_atkin);
+pub fn primes(c: &mut criterion::Criterion) {
+    c.bench_function("primes", |b| {
+        b.iter(|| utils::Primes::new(10i64.pow(6)).count())
+    });
+}
+
+criterion::criterion_group!(benches, is_prime, sieve_of_atkin, primes);
 criterion::criterion_main!(benches);

--- a/benches/benches.rs
+++ b/benches/benches.rs
@@ -13,9 +13,7 @@ pub fn sieve_of_atkin(c: &mut criterion::Criterion) {
 }
 
 pub fn primes(c: &mut criterion::Criterion) {
-    c.bench_function("primes", |b| {
-        b.iter(|| utils::Primes::new(10i64.pow(6)).count())
-    });
+    c.bench_function("primes", |b| b.iter(|| utils::Primes::new(10i64.pow(6)).count()));
 }
 
 criterion::criterion_group!(benches, is_prime, sieve_of_atkin, primes);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -235,6 +235,7 @@ pub use iterators::divisors::Divisors;
 pub use iterators::fibonacci::Fibonacci;
 pub use iterators::polygonal::Polygonal;
 pub use iterators::potential_primes::PotentialPrimes;
+pub use iterators::primes::Primes;
 pub use iterators::pythagorean_triplets::PythagoreanTriplets;
 
 #[cfg(test)]
@@ -365,6 +366,19 @@ mod tests {
     #[test]
     fn sieve_of_atkin_small_test() {
         let num_of_primes = utils::SieveOfAtkin::new(10usize.pow(9)).iter().count();
+        assert_eq!(num_of_primes, 50847534);
+    }
+
+    #[test]
+    fn primes_smaller_test() {
+        let num_of_primes = utils::Primes::new(2i64.pow(14)).count();
+        assert_eq!(num_of_primes, 1900);
+    }
+
+    #[cfg(any(target_pointer_width = "32", target_pointer_width = "64"))]
+    #[test]
+    fn primes_small_test() {
+        let num_of_primes = utils::Primes::new(10i64.pow(9)).count();
         assert_eq!(num_of_primes, 50847534);
     }
 

--- a/src/utils/iterators.rs
+++ b/src/utils/iterators.rs
@@ -7,4 +7,5 @@ pub mod divisors;
 pub mod fibonacci;
 pub mod polygonal;
 pub mod potential_primes;
+pub mod primes;
 pub mod pythagorean_triplets;

--- a/src/utils/iterators/primes.rs
+++ b/src/utils/iterators/primes.rs
@@ -1,0 +1,56 @@
+use crate::utils;
+
+/// Prime numbers.
+pub struct Primes {
+    initial_primes: std::array::IntoIter<i64, 3>,
+    potential_primes: utils::PotentialPrimes,
+    lookup: std::collections::HashMap<i64, i64>,
+    residues: u32,
+}
+
+impl Primes {
+    /// Generates the first three prime numbers (2, 3 and 5) unconditionally.
+    /// Then generates the prime numbers up to the given number.
+    ///
+    /// * `limit`
+    pub fn new(limit: i64) -> Self {
+        Self {
+            initial_primes: [2, 3, 5].into_iter(),
+            potential_primes: utils::PotentialPrimes::new(limit),
+            lookup: std::collections::HashMap::from([(9, 3), (25, 5)]),
+            residues: 0x208A2882,
+        }
+    }
+
+    fn next_initial_prime(&mut self) -> Option<i64> {
+        self.initial_primes.next()
+    }
+
+    fn next_other_prime(&mut self) -> Option<i64> {
+        loop {
+            let Some(potential_prime) = self.potential_primes.next() else {
+                return None;
+            };
+            match self.lookup.remove(&potential_prime) {
+                None => {
+                    self.lookup.insert(potential_prime.pow(2), potential_prime);
+                    return Some(potential_prime);
+                }
+                Some(offset) => {
+                    let mut num = potential_prime + 2 * offset;
+                    while self.lookup.contains_key(&num) || self.residues >> (num % 30) & 1 == 0 {
+                        num += 2 * offset;
+                    }
+                    self.lookup.insert(num, offset);
+                }
+            }
+        }
+    }
+}
+
+impl Iterator for Primes {
+    type Item = i64;
+    fn next(&mut self) -> Option<Self::Item> {
+        self.next_initial_prime().or_else(|| self.next_other_prime())
+    }
+}

--- a/src/utils/iterators/primes.rs
+++ b/src/utils/iterators/primes.rs
@@ -28,9 +28,7 @@ impl Primes {
 
     fn next_other_prime(&mut self) -> Option<i64> {
         loop {
-            let Some(potential_prime) = self.potential_primes.next() else {
-                return None;
-            };
+            let potential_prime = self.potential_primes.next()?;
             match self.lookup.remove(&potential_prime) {
                 None => {
                     self.lookup.insert(potential_prime.pow(2), potential_prime);


### PR DESCRIPTION
Serves to document my first attempt at implementing an indefinite prime sieve. Inspired by [this Stack Overflow question](https://stackoverflow.com/q/2211990).

Benchmarks indicate that my sieve of Atkin implementation is way faster than this implementation when both are executed up to a definite upper bound.

```
     Running benches/benches.rs (target/release/deps/benches-4a4f39c75b2fd568)
sieve_of_atkin          time:   [732.33 µs 733.87 µs 735.51 µs]
primes                  time:   [16.117 ms 16.137 ms 16.160 ms]
```